### PR TITLE
Added 'android' and 'ios' keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "keywords": [
     "react-native",
     "tab-bar",
-    "navigator"
+    "navigator",
+    "ios",
+    "android"
   ],
   "author": "James Ide",
   "license": "MIT",


### PR DESCRIPTION
...to display the supported platforms properly on https://react.parts
