### PR TITLE
Add `hidesTabTouch` property to disable the activeOpacity of the tab touchables

### DIFF
--- a/Tab.js
+++ b/Tab.js
@@ -18,6 +18,7 @@ export default class Tab extends React.Component {
     titleStyle: Text.propTypes.style,
     badge: PropTypes.element,
     onPress: PropTypes.func,
+    hidesTabTouch: PropTypes.bool
   };
 
   render() {
@@ -42,7 +43,7 @@ export default class Tab extends React.Component {
     let tabStyle = [styles.container, title ? null : styles.untitledContainer];
     return (
       <TouchableOpacity
-        activeOpacity={0.8}
+        activeOpacity={this.props.hidesTabTouch ? 1.0 : 0.8}
         onPress={this._handlePress}
         style={tabStyle}>
         <View>

--- a/TabBar.js
+++ b/TabBar.js
@@ -2,7 +2,6 @@
 
 import React, {
   Platform,
-  PropTypes,
   StyleSheet,
   View,
 } from 'react-native';
@@ -12,7 +11,7 @@ import Layout from './Layout';
 export default class TabBar extends React.Component {
   static propTypes = {
     ...View.propTypes,
-    shadowStyle: PropTypes.object,
+    shadowStyle: View.propTypes.style,
   }
 
   render() {

--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -7,6 +7,8 @@ import React, {
   View,
 } from 'react-native';
 
+import autobind from 'autobind-decorator';
+
 import Badge from './Badge';
 import Layout from './Layout';
 import StaticContainer from './StaticContainer';
@@ -20,6 +22,7 @@ export default class TabNavigator extends React.Component {
     sceneStyle: View.propTypes.style,
     tabBarStyle: TabBar.propTypes.style,
     tabBarShadowStyle: TabBar.propTypes.shadowStyle,
+    hidesTabTouch: PropTypes.bool
   };
 
   constructor(props, context) {
@@ -83,6 +86,7 @@ export default class TabNavigator extends React.Component {
     );
   }
 
+  @autobind
   _renderTab(item) {
     let icon;
     if (item.props.selected) {
@@ -116,7 +120,8 @@ export default class TabNavigator extends React.Component {
           ] : null,
         ]}
         badge={badge}
-        onPress={item.props.onPress}>
+        onPress={item.props.onPress}
+        hidesTabTouch={this.props.hidesTabTouch}>
         {icon}
       </Tab>
     );


### PR DESCRIPTION
Dimming the opacity on tab touch is not standard iOS behavior. Specifying `hidesTabTouch={true}` allows this component to be even more iOS-like.
