### PR TITLE
Get rid of badgeText warning on invalid PropType

### DIFF
--- a/TabNavigatorItem.js
+++ b/TabNavigatorItem.js
@@ -10,7 +10,7 @@ export default class TabNavigatorItem extends React.Component {
   static propTypes = {
     renderIcon: PropTypes.func.isRequired,
     renderSelectedIcon: PropTypes.func,
-    badgeText: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+    badgeText: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     renderBadge: PropTypes.func,
     title: PropTypes.string,
     titleStyle: Text.propTypes.style,


### PR DESCRIPTION
I get a warning when trying to initiate a `<TabNavigator.Item>` with `badgeText={"1"}` (as in example):

> Warning: Failed propType: Invalid prop `badgeText` of value `1` supplied to `TabNavigatorItem`, expected one of [null,null].

Changing its PropType to `oneOfType` resolved this warning.
