### PR TITLE
Export Badge as part of TabNavigator's API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ The API of this component may change in the future to be more like Navigator's, 
 
 ## Usage
 
+Import TabNavigator as a JavaScript module:
+
+```js
+import TabNavigator from 'react-native-tab-navigator';
+```
+
+This is an example of how to use the component and some of the commonly used props that it supports:
+
 ```js
 <TabNavigator>
   <TabNavigator.Item

--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -178,3 +178,4 @@ let styles = StyleSheet.create({
 });
 
 TabNavigator.Item = TabNavigatorItem;
+TabNavigator.Badge = Badge;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tab-navigator",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "A tab bar that switches between scenes, written in JS for cross-platform support",
   "main": "TabNavigator.js",
   "repository": {
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/exponentjs/react-native-tab-navigator#readme",
   "dependencies": {
-    "immutable": "^3.7.4"
+    "immutable": "^3.7.5"
   }
 }


### PR DESCRIPTION
So that we can easily customize the default Badge's styles and props.
