### PR TITLE
Allow font scaling

### DIFF
--- a/Tab.js
+++ b/Tab.js
@@ -29,14 +29,12 @@ export default class Tab extends React.Component {
   render() {
     let { title, badge } = this.props;
     let icon = React.Children.only(this.props.children);
-    // Default to true for undefined - like RN currently does
-    let scaleFont = (this.props.allowFontScaling === false) ? false : true;
 
     if (title) {
       title =
         <Text
           numberOfLines={1}
-          allowFontScaling={scaleFont}
+          allowFontScaling={!!this.props.allowFontScaling}
           style={[styles.title, this.props.titleStyle]}>
           {title}
         </Text>;

--- a/Tab.js
+++ b/Tab.js
@@ -30,7 +30,7 @@ export default class Tab extends React.Component {
     let { title, badge } = this.props;
     let icon = React.Children.only(this.props.children);
     // Default to true for undefined - like RN currently does
-    let scaleFont = (this.props.allowFontScaling === false) ? false : true
+    let scaleFont = (this.props.allowFontScaling === false) ? false : true;
 
     if (title) {
       title =
@@ -38,7 +38,7 @@ export default class Tab extends React.Component {
           numberOfLines={1}
           allowFontScaling={scaleFont}
           style={[styles.title, this.props.titleStyle]}>
-          {title}
+          !!{title}
         </Text>;
     }
 

--- a/Tab.js
+++ b/Tab.js
@@ -16,7 +16,8 @@ export default class Tab extends React.Component {
     titleStyle: Text.propTypes.style,
     badge: PropTypes.element,
     onPress: PropTypes.func,
-    hidesTabTouch: PropTypes.bool
+    hidesTabTouch: PropTypes.bool,
+    allowFontScaling: PropTypes.bool
   };
 
   constructor(props, context) {
@@ -28,11 +29,14 @@ export default class Tab extends React.Component {
   render() {
     let { title, badge } = this.props;
     let icon = React.Children.only(this.props.children);
+    // Default to true for undefined - like RN currently does
+    let scaleFont = (this.props.allowFontScaling === false) ? false : true
 
     if (title) {
       title =
         <Text
           numberOfLines={1}
+          allowFontScaling={scaleFont}
           style={[styles.title, this.props.titleStyle]}>
           {title}
         </Text>;

--- a/Tab.js
+++ b/Tab.js
@@ -38,7 +38,7 @@ export default class Tab extends React.Component {
           numberOfLines={1}
           allowFontScaling={scaleFont}
           style={[styles.title, this.props.titleStyle]}>
-          !!{title}
+          {title}
         </Text>;
     }
 

--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -111,6 +111,7 @@ export default class TabNavigator extends React.Component {
     return (
       <Tab
         title={item.props.title}
+        allowFontScaling={item.props.allowFontScaling}
         titleStyle={[
           item.props.titleStyle,
           item.props.selected ? [

--- a/TabNavigatorItem.js
+++ b/TabNavigatorItem.js
@@ -17,6 +17,7 @@ export default class TabNavigatorItem extends React.Component {
     selectedTitleStyle: Text.propTypes.style,
     selected: PropTypes.bool,
     onPress: PropTypes.func,
+    allowFontScaling: PropTypes.bool
   };
 
   static defaultProps = {


### PR DESCRIPTION
`allowFontScaling` passed down to tab React.Text components.  See image example with accessibility text turned up to the max. 
### Before

<img width="469" alt="screen shot 2015-12-25 at 8 42 27 pm" src="https://cloud.githubusercontent.com/assets/997157/12005030/7b68f72e-ab4f-11e5-8476-7c97f1a98668.png">
### Aftert - with `allowFontScaling={false}`

![image](https://cloud.githubusercontent.com/assets/997157/12005031/85f6e8d6-ab4f-11e5-8fab-c2a605a43480.png)
