### PR TITLE
Allow users to customize tab styles.

### DIFF
--- a/Tab.js
+++ b/Tab.js
@@ -46,7 +46,7 @@ export default class Tab extends React.Component {
       });
     }
 
-    let tabStyle = [styles.container, title ? null : styles.untitledContainer];
+    let tabStyle = [styles.container, title ? null : styles.untitledContainer, this.props.style];
     return (
       <TouchableOpacity
         activeOpacity={this.props.hidesTabTouch ? 1.0 : 0.8}

--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -112,6 +112,13 @@ export default class TabNavigator extends React.Component {
       <Tab
         title={item.props.title}
         allowFontScaling={item.props.allowFontScaling}
+        style={[
+          item.props.tabStyle,
+          item.props.selected ? [
+            styles.defaultSelectedTab,
+            item.props.selectedTabStyle,
+          ] : null,
+        ]}
         titleStyle={[
           item.props.titleStyle,
           item.props.selected ? [
@@ -170,12 +177,20 @@ let styles = StyleSheet.create({
     overflow: 'hidden',
     opacity: 0,
   },
+  defaultTab: {
+  },
   defaultSelectedTitle: {
     color: 'rgb(0, 122, 255)',
   },
   defaultSelectedIcon: {
     tintColor: 'rgb(0, 122, 255)',
   },
+  defaultSelectedIcon: {
+    // tintColor: 'rgb(0, 122, 255)',
+  },
+  defaultSelectedTab: {
+  },
+
 });
 
 TabNavigator.Item = TabNavigatorItem;


### PR DESCRIPTION
Support `tabStyle` and `selectedTabStyle` props on `TabNavigator.Item`.

![](http://g.recordit.co/CvhQnPn2iX.gif)

``` jsx
<TabNavigator
  tabBarStyle={styles.tabBar}
  sceneStyle={styles.scene}
  >
  <TabNavigator.Item
    title="ACCOUNT"
    selected={this.state.selectedTab === 'account'}
    onPress={() => { this.setState({ selectedTab: 'account' }) }}
    tabStyle={styles.tabBarItem}
    selectedTabStyle={styles.tabBarItemActive}
    titleStyle={styles.tabBarItemText}
    selectedTitleStyle={styles.tabBarItemActiveText}
    >
    // ...
```
