### PR TITLE
Allow child views to be updated as they are deselected

### DIFF
--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -135,6 +135,11 @@ class SceneContainer extends React.Component {
     selected: PropTypes.bool,
   };
 
+  componentWillUpdate(nextProps) {
+    // so child can be updated once when deselected, as well as while selected
+    this.shouldUpdateChild = (nextProps.selected || this.props.selected)
+  }
+
   render() {
     let { selected, ...props } = this.props;
     return (
@@ -147,7 +152,7 @@ class SceneContainer extends React.Component {
           selected ? null : styles.hiddenSceneContainer,
           props.style,
         ]}>
-        <StaticContainer shouldUpdate={selected}>
+        <StaticContainer shouldUpdate={this.shouldUpdateChild}>
           {this.props.children}
         </StaticContainer>
       </View>


### PR DESCRIPTION
Currently it's impossible to pass selected down to child views
because the static container blocks their updates unless selected,
so they never know when selected changes to false.

The change here allows the child to get one final update as it is
deselected, then continues to block updates until it's selected again.
