### PR TITLE
Custom styles for selected tabs and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ let tabBarHeight = 0;
 Since overflow hidden is not supported on Android, you can hide the tab bar by moving it off the screen. For example:
 
 ```js
+var Dimensions = require('Dimensions');
+
 if (hidden) {
     var tabBarStyle = {position: 'absolute', top: Dimensions.get('window').height};
     var sceneStyle = {paddingBottom: 0};

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This is an example of how to use the component and some of the commonly used pro
     title="Home"
     renderIcon={() => <Image source={...} />}
     renderSelectedIcon={() => <Image source={...} />}
+    selectedTabStyle={{backgroundColor: '...'}}
     badgeText="1"
     onPress={() => this.setState({ selectedTab: 'home' })}>
     {homeView}
@@ -40,6 +41,7 @@ This is an example of how to use the component and some of the commonly used pro
     title="Profile"
     renderIcon={() => <Image source={...} />}
     renderSelectedIcon={() => <Image source={...} />}
+    selectedTabStyle={{backgroundColor: '...'}}
     renderBadge={() => <CustomBadgeView />}
     onPress={() => this.setState({ selectedTab: 'profile' })}>
     {profileView}
@@ -49,13 +51,36 @@ This is an example of how to use the component and some of the commonly used pro
 
 See TabNavigatorItem's supported props for more info.
 
-### Hiding the Tab Bar
+## Hiding the Tab Bar
+
+### Hiding on iOS
 
 You can hide the tab bar by using styles. For example:
+
 ```js
 let tabBarHeight = 0;
 <TabNavigator
   tabBarStyle={{ height: tabBarHeight, overflow: 'hidden' }}
   sceneStyle={{ paddingBottom: tabBarHeight }}
+/>
+```
+
+### Hiding on Android
+
+Since overflow hidden is not supported on Android, you can hide the tab bar by moving it off the screen. For example:
+
+```js
+if (hidden) {
+    var tabBarStyle = {position: 'absolute', top: Dimensions.get('window').height};
+    var sceneStyle = {paddingBottom: 0};
+} else {
+    let tabBarHeight = 50;
+    var tabBarStyle = {height: tabBarHeight};
+    var sceneStyle = {paddingBottom: tabBarHeight};
+}
+
+<TabNavigator
+    tabBarStyle={tabBarStyle}
+    sceneStyle={sceneStyle}
 />
 ```

--- a/Tab.js
+++ b/Tab.js
@@ -14,6 +14,7 @@ export default class Tab extends React.Component {
   static propTypes = {
     title: PropTypes.string,
     titleStyle: Text.propTypes.style,
+    tabStyle: Text.propTypes.style,
     badge: PropTypes.element,
     onPress: PropTypes.func,
     hidesTabTouch: PropTypes.bool,
@@ -46,7 +47,7 @@ export default class Tab extends React.Component {
       });
     }
 
-    let tabStyle = [styles.container, title ? null : styles.untitledContainer];
+    let tabStyle = [styles.container, title ? null : styles.untitledContainer, this.props.tabStyle];
     return (
       <TouchableOpacity
         activeOpacity={this.props.hidesTabTouch ? 1.0 : 0.8}

--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -119,6 +119,10 @@ export default class TabNavigator extends React.Component {
             item.props.selectedTitleStyle,
           ] : null,
         ]}
+        tabStyle={[
+          item.props.tabStyle,
+          item.props.selected ? item.props.selectedTabStyle : null,
+        ]}
         badge={badge}
         onPress={item.props.onPress}
         hidesTabTouch={this.props.hidesTabTouch}>

--- a/TabNavigatorItem.js
+++ b/TabNavigatorItem.js
@@ -15,6 +15,8 @@ export default class TabNavigatorItem extends React.Component {
     title: PropTypes.string,
     titleStyle: Text.propTypes.style,
     selectedTitleStyle: Text.propTypes.style,
+    tabStyle: Text.propTypes.style,
+    selectedTabStyle: Text.propTypes.style,
     selected: PropTypes.bool,
     onPress: PropTypes.func,
     allowFontScaling: PropTypes.bool


### PR DESCRIPTION
Added a change to update the style for selected tabs. For example:

``` js
selectedTabStyle={{backgroundColor: '...'}}
```

Also updated the readme to reflect the above change as well as an option of how to hide the navigation on Android.
