### PR TITLE
Fix a vertical alignment problem when rendering untitled tab icons

### DIFF
--- a/Tab.js
+++ b/Tab.js
@@ -47,13 +47,12 @@ export default class Tab extends React.Component {
       });
     }
 
-    let tabStyle = [styles.container, title ? null : styles.untitledContainer];
     return (
       <TouchableOpacity
         testID={this.props.testID}
         activeOpacity={this.props.hidesTabTouch ? 1.0 : 0.8}
         onPress={this._handlePress}
-        style={tabStyle}>
+        style={styles.container}>
         <View>
           {icon}
           {badge}
@@ -81,9 +80,6 @@ let styles = StyleSheet.create({
     flexDirection: 'column',
     justifyContent: 'flex-end',
     alignItems: 'center',
-  },
-  untitledContainer: {
-    paddingBottom: 13,
   },
   title: {
     color: '#929292',


### PR DESCRIPTION
I meet a vertical alignment problem when rendering untitled tab icons.
Delete the untitledContainer style and let developer themselves to render the untitled tab icon may be more appropriate.😊
