### PR TITLE
Add ability to pass styles for each individual tab

### DIFF
--- a/Tab.js
+++ b/Tab.js
@@ -13,6 +13,7 @@ import Layout from './Layout';
 export default class Tab extends React.Component {
   static propTypes = {
     testID : PropTypes.string,
+    style: View.propTypes.style,
     title: PropTypes.string,
     titleStyle: Text.propTypes.style,
     badge: PropTypes.element,
@@ -53,7 +54,7 @@ export default class Tab extends React.Component {
         testID={this.props.testID}
         activeOpacity={this.props.hidesTabTouch ? 1.0 : 0.8}
         onPress={this._handlePress}
-        style={tabStyle}>
+        style={[tabStyle, this.props.style]}>
         <View>
           {icon}
           {badge}

--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -20,6 +20,8 @@ export default class TabNavigator extends React.Component {
     sceneStyle: View.propTypes.style,
     tabBarStyle: TabBar.propTypes.style,
     tabBarShadowStyle: TabBar.propTypes.shadowStyle,
+    tabStyle: Tab.propTypes.style,
+    selectedTabStyle: Tab.propTypes.style,
     hidesTabTouch: PropTypes.bool
   };
 
@@ -113,6 +115,12 @@ export default class TabNavigator extends React.Component {
         testID={item.props.testID}
         title={item.props.title}
         allowFontScaling={item.props.allowFontScaling}
+        style={[
+          item.props.tabStyle,
+          item.props.selected ?
+            item.props.selectedTabStyle :
+            null
+        ]}
         titleStyle={[
           item.props.titleStyle,
           item.props.selected ? [

--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -119,7 +119,7 @@ export default class TabNavigator extends React.Component {
           item.props.tabStyle,
           item.props.selected ?
             item.props.selectedTabStyle :
-            null
+            null,
         ]}
         titleStyle={[
           item.props.titleStyle,


### PR DESCRIPTION
## Why?

In one of our projects, there is a need to have a different background color for a selected tab (example below).
## What changed?
- Added `tabStyle` and `selectedTabStyle` props to `TabNavigator`
  - The correct styles are passed down to `Tab` based on if the tab is selected
  - I'm only planning on using `selectedTabStyle` and it seems having a different style per tab is an anti-pattern (as is pointed out in [Material Design's Bottom Navigation docs](https://www.google.com/design/spec/components/bottom-navigation.html#bottom-navigation-style)), but I guess configurability is good? `¯\_(ツ)_/¯`

<img width="487" alt="screen shot 2016-04-26 at 9 17 21 pm" src="https://cloud.githubusercontent.com/assets/1641918/14838990/febf5072-0bf4-11e6-8fea-b894b4096471.png">
