### PR TITLE
Ignore null children in the tab-bar.

### DIFF
--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -51,6 +51,9 @@ export default class TabNavigator extends React.Component {
   _updateRenderedSceneKeys(children, oldSceneKeys = Set()): Set {
     let newSceneKeys = Set().asMutable();
     React.Children.forEach(children, (item, index) => {
+      if (item === null) {
+        return;
+      }
       let key = this._getSceneKey(item, index);
       if (oldSceneKeys.has(key) || item.props.selected) {
         newSceneKeys.add(key);
@@ -64,6 +67,9 @@ export default class TabNavigator extends React.Component {
     let scenes = [];
 
     React.Children.forEach(children, (item, index) => {
+      if (item === null) {
+        return;
+      }
       let sceneKey = this._getSceneKey(item, index);
       if (!this.state.renderedSceneKeys.has(sceneKey)) {
         return;
@@ -90,6 +96,9 @@ export default class TabNavigator extends React.Component {
 
   _renderTab(item) {
     let icon;
+    if (item === null) {
+      return;
+    }
     if (item.props.selected) {
       if (item.props.renderSelectedIcon) {
         icon = item.props.renderSelectedIcon();


### PR DESCRIPTION
This allows you to render tab items conditonally since the false
condition returns null in that case.
