### PR TITLE
Feature floating scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,17 @@ let tabBarHeight = 0;
   sceneStyle={{ paddingBottom: tabBarHeight }}
 />
 ```
+### Floating Scene
+`floatingScene` prop allows you to inject an additional scene
+that renders on top of all other scenes and is always visible across different selected tabs/scene. A practical example could be the mini music player in Apple Music app,
+that  appears behind the tabs navigator and  is always visible across the different scenes.
+
+```js
+  var floatComp = (props) => {
+    return (<View><Text>This will be on top of other scenes</Text></View>)
+  }
+
+  <TabNavigator
+    floatingScene={floatComp()}
+  >
+```

--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -62,6 +62,7 @@ export default class TabNavigator extends React.Component {
     let scenes = [];
 
     React.Children.forEach(children, (item, index) => {
+      let floatingScene = (this.props.floatingScene) ? this.props.floatingScene : null;
       let sceneKey = this._getSceneKey(item, index);
       if (!this.state.renderedSceneKeys.has(sceneKey)) {
         return;
@@ -79,6 +80,7 @@ export default class TabNavigator extends React.Component {
     return (
       <View {...props} style={[styles.container, style]}>
         {scenes}
+        {floatingScene}
         <TabBar style={tabBarStyle} shadowStyle={tabBarShadowStyle}>
           {React.Children.map(children, this._renderTab)}
         </TabBar>


### PR DESCRIPTION
`floatingScene` prop allows you to inject an additional scene
that renders on top of all other scenes and is always visible across different selected tabs/scene. A practical example could be the mini music player in Apple Music app
that  appears behind the tabs navigator and  is always visible across the different scenes.
`
