### PR TITLE
floatingScene prop allows you to inject an additional scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ TabNavigator props
 | tabBarStyle | inherited | object (style) | define style for TabBar |
 | tabBarShadowStyle | inherited | object (style) | define shadow style for tabBar |
 | hidesTabTouch | false | boolean | disable onPress opacity for Tab |
+| floatingScene | null | Component | additinal scene rendered on top and is visible across scenes |
 
 TabNavigator.Item props
 

--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -63,6 +63,7 @@ export default class TabNavigator extends React.Component {
   }
 
   render() {
+    let floatingScene = (this.props.floatingScene) ? this.props.floatingScene : null;
     let { style, children, tabBarStyle, tabBarShadowStyle, sceneStyle, ...props } = this.props;
     let scenes = [];
 
@@ -87,6 +88,7 @@ export default class TabNavigator extends React.Component {
     return (
       <View {...props} style={[styles.container, style]}>
         {scenes}
+        {floatingScene}
         <TabBar style={tabBarStyle} shadowStyle={tabBarShadowStyle}>
           {React.Children.map(children, this._renderTab)}
         </TabBar>


### PR DESCRIPTION
That renders on top of all other scenes and is always visible across different selected tabs/scene. A practical example could be the mini music player in Apple Music app
that appears behind the tabs navigator and is always visible across the different scenes.
