### PR TITLE
Fix styling for Tab

### DIFF
--- a/Tab.js
+++ b/Tab.js
@@ -63,7 +63,7 @@ export default class Tab extends React.Component {
         activeOpacity={this.props.hidesTabTouch ? 1.0 : 0.8}
         onPress={this._handlePress}
         style={tabStyle}>
-        <View>
+        <View style={tabStyle}>
           {icon}
           {badge}
         </View>


### PR DESCRIPTION
I couldn't use styling like:
```
tabStyle={
  justifyContent: 'center'
}
```

because the actual tab is wrapped inside a `<View>` that does not get the style props passed through.