### PR TITLE
Added ability to hide tab from tabbar but keep functionality.

### DIFF
--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -96,7 +96,7 @@ export default class TabNavigator extends React.Component {
 
   _renderTab(item) {
     let icon;
-    if (item === null) {
+    if (item === null || (item.props.hideTab && item.props.hideTab === true)) {
       return;
     }
     if (item.props.selected) {
@@ -131,6 +131,7 @@ export default class TabNavigator extends React.Component {
             item.props.selectedTitleStyle,
           ] : null,
         ]}
+        hideTab={item.props.hideTab}
         badge={badge}
         onPress={item.props.onPress}
         hidesTabTouch={this.props.hidesTabTouch}


### PR DESCRIPTION
This is for views that don't need to be in the TabBar, such as Sign Up, Login and so on.
One can basically use "external" links to navigate to tabs which not appear in the tab bar.

Example:
<TabNavigator.Item
                        selected={this.state.selectedTab === 'UserSignUpScreen'}
                        title="Sign Up"
                        **hideTab={true}**
                        selectedTitleStyle={{color: '#fff'}}
                        titleStyle={{color: '#fff'}}
                        renderIcon={() => <IconSoc name="alert-octagon" style={{fontSize: 20, color: '#fff'}}    />}
                        renderSelectedIcon={() => <IconSoc name="alert-octagon" style={{fontSize: 20, color: '#bfeffc'}} />}
                        onPress={() => this.changetab('selectedTab', 'UserSignUpScreen')}>