### PR TITLE
Add iPhone X support using RN-safe-area

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TabNavigator
-A tab bar that switches between scenes, written in JS for cross-platform support. It works on iOS and Android.
+A tab bar that switches between scenes, written in JS for cross-platform support. It works on iOS and Android, and supports iPhone X out of the box.
 
 This component is compatible with React Native 0.16 and newer.
 
@@ -17,7 +17,15 @@ Install
 
 Make sure that you are in your React Native project directory and run:
 
-```npm install react-native-tab-navigator --save```
+`npm install react-native-tab-navigator --save`
+
+Then, link *react-native-safe-area* using:
+
+`react-native link react-native-safe-area`
+
+> **Why do I need to do this?**
+>
+> This allows TabNavigator to be aware of recent iOS 11 Safe Area concepts. It is the best way to deal with the new iPhone X, and any other future iOS layout changes.
 
 ## Usage
 
@@ -91,5 +99,3 @@ TabNavigator.Item props
 | selected | none | boolean | return whether the item is selected |
 | onPress | none | function | onPress method for Item |
 | allowFontScaling | false | boolean | allow font scaling for title |
-
-

--- a/TabBar.js
+++ b/TabBar.js
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
+import SafeArea from 'react-native-safe-area';
 
 import ViewPropTypes from './config/ViewPropTypes';
 import Layout from './Layout';
@@ -17,9 +18,22 @@ export default class TabBar extends React.Component {
     shadowStyle: ViewPropTypes.style,
   };
 
+  constructor(props) {
+    super(props)
+    const self = this
+    this.state = { safeBottom: 0 }
+    SafeArea.getSafeAreaInsetsForRootView().then((res) => {
+      self.setState({ safeBottom: res.safeAreaInsets.bottom})
+    })
+  }
+
   render() {
+    const safeStyle = {
+      height: Layout.tabBarHeight + this.state.safeBottom,
+      paddingBottom: this.state.safeBottom,
+    }
     return (
-      <Animated.View {...this.props} style={[styles.container, this.props.style]}>
+      <Animated.View {...this.props} style={[styles.container, safeStyle, this.props.style]}>
         {this.props.children}
         <View style={[styles.shadow, this.props.shadowStyle]} />
       </Animated.View>
@@ -32,7 +46,6 @@ let styles = StyleSheet.create({
     backgroundColor: '#f8f8f8',
     flexDirection: 'row',
     justifyContent: 'space-around',
-    height: Layout.tabBarHeight,
     position: 'absolute',
     bottom: 0,
     left: 0,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/exponentjs/react-native-tab-navigator#readme",
   "dependencies": {
     "immutable": "^3.8.1",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "react-native-safe-area": "^0.2.1"
   }
 }


### PR DESCRIPTION
This adds iPhone X support for TabNavigator using [react-native-safe-area](https://github.com/miyabi/react-native-safe-area).

This method contains no hard-coded value for the iPhone X.
Instead, it uses RN-safe-area which needs to be linked using `react-native link` but ensures future-proofing for any potential upcoming devices or layout changes by using iOS 11's Safe Area concept.

I used this technique myself, and I thought it might be worth adding it to TabNavigator directly.